### PR TITLE
feat: asistentes en eventos

### DIFF
--- a/backCripta/src/events/events.controller.ts
+++ b/backCripta/src/events/events.controller.ts
@@ -7,7 +7,9 @@ import {
   Put,
   Delete,
   UseGuards,
+  Req,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { EventsService } from './events.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -48,5 +50,23 @@ export class EventsController {
   @Roles('ADMIN')
   async remove(@Param('id') id: string) {
     return this.eventsService.remove(id);
+  }
+
+  @Post(':id/asistentes')
+  @Roles('MEMBER')
+  async joinEvent(@Param('id') eventId: string, @Req() req: Request) {
+    return this.eventsService.joinEvent(eventId, (req.user as any).id);
+  }
+
+  @Delete(':id/asistentes')
+  @Roles('MEMBER')
+  async leaveEvent(@Param('id') eventId: string, @Req() req: Request) {
+    return this.eventsService.leaveEvent(eventId, (req.user as any).id);
+  }
+
+  @Get(':id/asistentes')
+  @Roles('ADMIN')
+  async getAttendees(@Param('id') eventId: string) {
+    return this.eventsService.getAttendees(eventId);
   }
 }

--- a/backCripta/src/events/events.module.ts
+++ b/backCripta/src/events/events.module.ts
@@ -3,10 +3,12 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { EventsController } from './events.controller';
 import { EventsService } from './events.service';
 import { Event, EventSchema } from './schemas/events.schema';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Event.name, schema: EventSchema }]),
+    UsersModule,
   ],
   controllers: [EventsController],
   providers: [EventsService],

--- a/backCripta/src/events/events.service.ts
+++ b/backCripta/src/events/events.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -8,11 +9,13 @@ import { isValidObjectId, Model } from 'mongoose';
 import { Event, EventDocument } from './schemas/events.schema';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class EventsService {
   constructor(
     @InjectModel(Event.name) private eventModel: Model<EventDocument>,
+    private usersService: UsersService,
   ) {}
 
   async create(createEventDto: CreateEventDto): Promise<Event> {
@@ -67,5 +70,77 @@ export class EventsService {
     }
 
     return event;
+  }
+
+  async joinEvent(eventId: string, userId: string): Promise<Event> {
+    if (!isValidObjectId(eventId)) {
+      throw new BadRequestException('ID de evento inválido');
+    }
+
+    const event = await this.eventModel.findById(eventId).exec();
+    if (!event) {
+      throw new NotFoundException('Evento no encontrado');
+    }
+
+    const user = await this.usersService.findBasicInfo(userId);
+    if (!user || user.status !== 'Activo') {
+      throw new ForbiddenException('Solo los socios con membresía activa pueden apuntarse a eventos');
+    }
+
+    const yaApuntado = event.attendees.some((a) => a.userId === userId);
+    if (yaApuntado) {
+      throw new BadRequestException('Ya estás apuntado a este evento');
+    }
+
+    event.attendees.push({ userId, joinedAt: new Date() });
+    await event.save();
+
+    return event.populate('label');
+  }
+
+  async leaveEvent(eventId: string, userId: string): Promise<Event> {
+    if (!isValidObjectId(eventId)) {
+      throw new BadRequestException('ID de evento inválido');
+    }
+
+    const event = await this.eventModel.findById(eventId).exec();
+    if (!event) {
+      throw new NotFoundException('Evento no encontrado');
+    }
+
+    const index = event.attendees.findIndex((a) => a.userId === userId);
+    if (index === -1) {
+      throw new BadRequestException('No estás apuntado a este evento');
+    }
+
+    event.attendees.splice(index, 1);
+    await event.save();
+
+    return event.populate('label');
+  }
+
+  async getAttendees(eventId: string) {
+    if (!isValidObjectId(eventId)) {
+      throw new BadRequestException('ID de evento inválido');
+    }
+
+    const event = await this.eventModel.findById(eventId).exec();
+    if (!event) {
+      throw new NotFoundException('Evento no encontrado');
+    }
+
+    const attendeesWithInfo = await Promise.all(
+      event.attendees.map(async (attendee) => {
+        const userInfo = await this.usersService.findBasicInfo(attendee.userId);
+        return {
+          userId: attendee.userId,
+          joinedAt: attendee.joinedAt,
+          name: userInfo?.name ?? 'Usuario eliminado',
+          email: userInfo?.email ?? null,
+        };
+      }),
+    );
+
+    return attendeesWithInfo;
   }
 }

--- a/backCripta/src/events/schemas/events.schema.ts
+++ b/backCripta/src/events/schemas/events.schema.ts
@@ -5,6 +5,11 @@ export type EventDocument = HydratedDocument<Event>;
 
 export const EVENT_STATUSES = ['Próximo', 'En curso', 'Finalizado'] as const;
 
+export class Attendee {
+  userId: string;
+  joinedAt: Date;
+}
+
 @Schema({ timestamps: true })
 export class Event {
   @Prop({ required: true })
@@ -24,6 +29,12 @@ export class Event {
 
   @Prop({ default: 'Próximo', enum: EVENT_STATUSES })
   status!: string;
+
+  @Prop({
+    type: [{ userId: { type: String, required: true }, joinedAt: { type: Date, default: Date.now } }],
+    default: [],
+  })
+  attendees!: Attendee[];
 }
 
 export const EventSchema = SchemaFactory.createForClass(Event);

--- a/backCripta/src/users/users.controller.ts
+++ b/backCripta/src/users/users.controller.ts
@@ -27,7 +27,7 @@ export class UsersController {
   }
 
   @Get()
-  @Roles('ADMIN') //
+  @Roles('ADMIN')
   async findAll() {
     return this.usersService.findAll();
   }
@@ -42,6 +42,12 @@ export class UsersController {
   @Roles('ADMIN')
   async update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
     return this.usersService.update(id, updateUserDto);
+  }
+
+  @Put(':id/membresia')
+  @Roles('ADMIN')
+  async renewMembership(@Param('id') id: string) {
+    return this.usersService.renewMembership(id);
   }
 
   @Delete(':id')

--- a/backCripta/src/users/users.module.ts
+++ b/backCripta/src/users/users.module.ts
@@ -7,5 +7,6 @@ import { PrismaModule } from 'src/prisma/prisma.module';
   imports: [PrismaModule],
   providers: [UsersService],
   controllers: [UsersController],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/backCripta/src/users/users.service.ts
+++ b/backCripta/src/users/users.service.ts
@@ -76,6 +76,13 @@ export class UsersService {
     return user;
   }
 
+  async findBasicInfo(id: string) {
+    return this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true, name: true, email: true, status: true },
+    });
+  }
+
   async update(id: string, data: UpdateUserDto) {
     if (data.password) {
       data.password = await bcrypt.hash(data.password, 10);
@@ -100,6 +107,38 @@ export class UsersService {
       }
       if (error.code === 'P2002') {
         throw new ConflictException('El email o DNI ya está registrado');
+      }
+      throw error;
+    }
+  }
+
+  async renewMembership(id: string) {
+    const today = new Date();
+    const expiration = new Date(today);
+    expiration.setMonth(expiration.getMonth() + 1);
+
+    const format = (d: Date) => d.toISOString().split('T')[0];
+
+    try {
+      return await this.prisma.user.update({
+        where: { id },
+        data: {
+          status: 'Activo',
+          lastRenewal: format(today),
+          expirationDate: format(expiration),
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          status: true,
+          lastRenewal: true,
+          expirationDate: true,
+        },
+      });
+    } catch (error) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException('Usuario no encontrado');
       }
       throw error;
     }


### PR DESCRIPTION
- Event schema: nuevo campo attendees [{ userId, joinedAt }]
- UsersModule exporta UsersService; EventsModule lo importa para cruzar datos Postgres ↔ Mongo
- UsersService: nuevo método findBasicInfo(id) para consulta interna sin lanzar excepción
- POST /eventos/:id/asistentes (MEMBER): apunta al usuario validando status === 'Activo' en Postgres
- DELETE /eventos/:id/asistentes (MEMBER): desapunta al usuario del token JWT
- GET /eventos/:id/asistentes (ADMIN): lista enriquecida con nombre y email desde Postgres
- PUT /usuarios/:id/membresia (ADMIN): renueva membresía automáticamente con status='Activo', lastRenewal=hoy y expirationDate=hoy+1mes