### PR TITLE
[Épica Contacto] Permite cambiar el estado de mensajes desde la API

### DIFF
--- a/backCripta/src/contact/contact.controller.ts
+++ b/backCripta/src/contact/contact.controller.ts
@@ -2,13 +2,16 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Body,
+  Param,
   HttpCode,
   HttpStatus,
   UseGuards,
 } from '@nestjs/common';
 import { ContactService } from './contact.service';
 import { CreateMessageDto } from './dto/create-message.dto';
+import { UpdateMessageStatusDto } from './dto/update-message-status.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -28,6 +31,16 @@ export class ContactController {
   @Roles('ADMIN')
   async getContactMessages() {
     return this.contactService.getMessages();
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async updateContactMessageStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateMessageStatusDto,
+  ) {
+    return this.contactService.updateMessageStatus(id, dto);
   }
 
   @Get('redes')

--- a/backCripta/src/contact/contact.service.ts
+++ b/backCripta/src/contact/contact.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { isValidObjectId, Model } from 'mongoose';
 import { ContactMessage, ContactMessageDocument } from './schemas/contact-message.schema';
 import { SocialLink, SocialLinkDocument } from './schemas/social-link.schema';
 import { CreateMessageDto } from './dto/create-message.dto';
+import { UpdateMessageStatusDto } from './dto/update-message-status.dto';
 
 @Injectable()
 export class ContactService {
@@ -25,6 +26,22 @@ export class ContactService {
 
   async getMessages() {
     return this.messageModel.find().sort({ createdAt: -1 });
+  }
+
+  async updateMessageStatus(id: string, dto: UpdateMessageStatusDto) {
+    if (!isValidObjectId(id)) {
+      throw new BadRequestException('ID de mensaje invalido');
+    }
+
+    const message = await this.messageModel
+      .findByIdAndUpdate(id, { estado: dto.estado }, { returnDocument: 'after' })
+      .exec();
+
+    if (!message) {
+      throw new NotFoundException('Mensaje de contacto no encontrado');
+    }
+
+    return message;
   }
 
   async getSocialLinks() {

--- a/backCripta/src/contact/dto/update-message-status.dto.ts
+++ b/backCripta/src/contact/dto/update-message-status.dto.ts
@@ -1,0 +1,10 @@
+import { IsIn } from 'class-validator';
+import {
+  CONTACT_MESSAGE_STATUSES,
+  type ContactMessageStatus,
+} from '../schemas/contact-message.schema';
+
+export class UpdateMessageStatusDto {
+  @IsIn(CONTACT_MESSAGE_STATUSES)
+  estado!: ContactMessageStatus;
+}

--- a/backCripta/src/contact/schemas/contact-message.schema.ts
+++ b/backCripta/src/contact/schemas/contact-message.schema.ts
@@ -2,6 +2,14 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
 
 export type ContactMessageDocument = HydratedDocument<ContactMessage>;
+export const CONTACT_MESSAGE_STATUSES = [
+  'pendiente',
+  'en_proceso',
+  'respondido',
+  'resuelto',
+  'archivado',
+] as const;
+export type ContactMessageStatus = (typeof CONTACT_MESSAGE_STATUSES)[number];
 
 @Schema({ timestamps: true })
 export class ContactMessage {
@@ -17,8 +25,8 @@ export class ContactMessage {
   @Prop({ required: true })
   mensaje!: string;
 
-  @Prop({ default: 'pendiente' })
-  estado!: string;
+  @Prop({ enum: CONTACT_MESSAGE_STATUSES, default: 'pendiente' })
+  estado!: ContactMessageStatus;
 }
 
 export const ContactMessageSchema = SchemaFactory.createForClass(ContactMessage);

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -187,6 +187,7 @@ Base URL via Nginx: `http://localhost:8080/api`
 | ------ | ---- | ---- | ----- | ---------- |
 | POST | `/contacto` | No | Publico | `CreateMessageDto` |
 | GET | `/contacto` | JWT | ADMIN | Lista mensajes de contacto |
+| PATCH | `/contacto/:id` | JWT | ADMIN | Cambia el estado de un mensaje |
 | GET | `/contacto/redes` | No | Publico | Devuelve enlaces sociales |
 | GET | `/contacto/twitch` | No | Publico | Devuelve informacion del stream de Twitch |
 
@@ -200,6 +201,22 @@ Base URL via Nginx: `http://localhost:8080/api`
   "mensaje": "string (requerido)"
 }
 ```
+
+**UpdateMessageStatusDto:**
+
+```json
+{
+  "estado": "pendiente | en_proceso | respondido | resuelto | archivado"
+}
+```
+
+Estados disponibles:
+
+- `pendiente`: Pendiente
+- `en_proceso`: En proceso
+- `respondido`: Respondido
+- `resuelto`: Resuelto
+- `archivado`: Archivado
 
 ---
 


### PR DESCRIPTION
## Objetivo
Añade soporte en backend para actualizar el estado de los mensajes de contacto desde la app, alineando la API con el selector de estados ya disponible en el frontend.

## Cambios principales
* Se añadió `PATCH /contacto/:id` protegido para `ADMIN`.
* Se creó `UpdateMessageStatusDto` para validar el estado entrante.
* Se limitó el campo `estado` del esquema de Mongo a los valores permitidos: `pendiente`, `en_proceso`, `respondido`, `resuelto` y `archivado`.
* Se actualizó la documentación de endpoints con el nuevo contrato.

## UI / UX (Solo si aplica)
* No aplica; el cambio es de API y validación de datos.

## Changelog
* No se creó ni actualizó archivo en `changelog/`.

## Testing
* `npm run build` en `backCripta` completado con éxito.
* `npm test` no se ejecutó correctamente porque la instalación local de Jest no resuelve `ts-jest`.